### PR TITLE
dynaconf 3.2.13

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-upload_channels:
-  - defaults

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 upload_channels:
-  - sfe1ed40
+  - defaults

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "dynaconf" %}
-{% set version = "3.2.4" %}
+{% set version = "3.2.13" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 2e6adebaa587f4df9241a16a4bec3fda521154d26b15f3258fde753a592831b6
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: d79e0189d97b3f226b8ebb1717e2ce05d1a05cdf6ea05de66d24625fdb5a0cbd
 
 build:
   number: 0
@@ -42,7 +42,7 @@ about:
   summary: Configuration Management for Python
   description: Configuration Management for Python
   doc_url: https://www.dynaconf.com/
-  dev_url: https://github.com/rochacbruno/dynaconf
+  dev_url: https://github.com/dynaconf/dynaconf
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,6 @@ requirements:
     - python
     - setuptools
     - pip
-    - wheel
   run:
     - python
 
@@ -35,13 +34,13 @@ test:
     - dynaconf --help
 
 about:
-  home: https://www.dynaconf.com/
+  home: https://www.dynaconf.com
   license: MIT
   license_family: MIT
   license_file: LICENSE
   summary: Configuration Management for Python
   description: Configuration Management for Python
-  doc_url: https://www.dynaconf.com/
+  doc_url: https://www.dynaconf.com
   dev_url: https://github.com/dynaconf/dynaconf
 
 extra:


### PR DESCRIPTION
## dynaconf 3.2.13

**Destination channel:** defaults

### Links

- [PKG-13095](https://anaconda.atlassian.net/browse/PKG-13095)
- [PyPI](https://pypi.org/project/dynaconf/3.2.13/)
- [Upstream repository](https://github.com/dynaconf/dynaconf)

### Explanation of changes:

- Updated dynaconf from 3.2.4 to 3.2.13
- Source URL fixed from pypi.io to pypi.org
- dev_url updated (repo moved from rochacbruno/dynaconf to dynaconf/dynaconf)
- Removed trailing slashes from home/doc URLs
- Removed unnecessary wheel from host deps
- No dependency changes (dynaconf has no runtime deps beyond Python)

> **Note:** `abs.yaml` currently contains `staging_channel_upload_target` for the evidently dependency chain bootstrap. This will be removed (abs.yaml cleaned up) in a follow-up commit once the PR is approved and before final merge to master.

[PKG-13095]: https://anaconda.atlassian.net/browse/PKG-13095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ